### PR TITLE
feat: Integrate nodemailer for password reset emails

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@types/jsonwebtoken": "^9.0.9",
     "@types/morgan": "^1.9.10",
     "@types/pg": "^8.15.4",
+    "@types/nodemailer": "^6.4.17",
+    "@types/uuid": "^10.0.0",
     "nodemon": "^3.1.10",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
@@ -30,6 +32,8 @@
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
     "pg": "^8.16.0",
-    "reflect-metadata": "^0.2.2"
+    "reflect-metadata": "^0.2.2",
+    "nodemailer": "^7.0.3",
+    "uuid": "^11.1.0"
   }
 }

--- a/src/application/use-cases/auth.use-case.ts
+++ b/src/application/use-cases/auth.use-case.ts
@@ -10,6 +10,7 @@ import { HttpError } from "../../domain/errors/http.error";
 import { HttpStatusCode } from "../../domain/shared/http.status";
 import { User } from "../../domain/entities/user";
 import { IMailService } from "../../domain/services/mail.service";
+import { v4 as uuidv4 } from 'uuid'; // Import uuid
 
 @injectable()
 export class LoginUseCase {
@@ -72,7 +73,12 @@ export class RestorePasswordUseCase {
         const existUser = await this.userRepository.findByEmail(email);
         if (!existUser) throw new HttpError(HttpStatusCode.NOT_FOUND, 'User not found.');
 
-        await this.mailService.sendRestorePasswordEmail(email);
+        const token = uuidv4(); // Generate token
+
+        // In a real application, you would save the token with user ID and expiry
+        // For example: await this.passwordResetRepository.createToken(existUser.id, token, expiryDate);
+
+        await this.mailService.sendRestorePasswordEmail(email, token); // Pass token
 
         return [HttpStatusCode.OK, { message: 'Email sended successfully.' }];
     }

--- a/src/domain/services/mail.service.ts
+++ b/src/domain/services/mail.service.ts
@@ -1,3 +1,3 @@
 export interface IMailService {
-    sendRestorePasswordEmail(email: string): Promise<void>;
+    sendRestorePasswordEmail(email: string, token: string): Promise<void>;
 }

--- a/src/infraestructure/config/env.ts
+++ b/src/infraestructure/config/env.ts
@@ -5,5 +5,12 @@ export const config = {
     PSQL_USER: process.env.PSQL_USER as string,
     PSQL_PASSWORD: process.env.PSQL_PASSWORD as string,
     PSQL_HOST: process.env.PSQL_HOST as string,
-    PSQL_PORT: Number.parseInt(process.env.PSQL_PORT as string) as number
+    PSQL_PORT: Number.parseInt(process.env.PSQL_PORT as string) as number,
+
+    // Email configuration
+    SMTP_HOST: process.env.SMTP_HOST as string,
+    SMTP_PORT: Number.parseInt(process.env.SMTP_PORT as string) as number,
+    SMTP_USER: process.env.SMTP_USER as string,
+    SMTP_PASS: process.env.SMTP_PASS as string,
+    EMAIL_FROM: process.env.EMAIL_FROM as string,
 }

--- a/src/infraestructure/driven/services/node-mailer.service.ts
+++ b/src/infraestructure/driven/services/node-mailer.service.ts
@@ -1,9 +1,39 @@
 import { injectable } from "inversify";
+import * as nodemailer from 'nodemailer';
 import { IMailService } from "../../../domain/services/mail.service";
+import { config } from "../../config/env"; // Correct path to env config
 
 @injectable()
 export class NodeMailerService implements IMailService {
-    public async sendRestorePasswordEmail(email: string): Promise<void> {
-        throw new Error("Method not implemented.");
+    private transporter: nodemailer.Transporter;
+
+    constructor() {
+        this.transporter = nodemailer.createTransport({
+            host: config.SMTP_HOST,
+            port: config.SMTP_PORT,
+            secure: config.SMTP_PORT === 465, // true for 465, false for other ports
+            auth: {
+                user: config.SMTP_USER,
+                pass: config.SMTP_PASS,
+            },
+        });
+    }
+
+    public async sendRestorePasswordEmail(email: string, token: string): Promise<void> { // Added token parameter
+        const mailOptions = {
+            from: config.EMAIL_FROM,
+            to: email,
+            subject: 'Password Reset Request',
+            html: `<p>You requested a password reset. Please use the following token to reset your password: <strong>${token}</strong></p><p>If you didn't request this, please ignore this email.</p>`,
+        };
+
+        try {
+            await this.transporter.sendMail(mailOptions);
+            console.log(`Password reset email sent to ${email}`);
+        } catch (error) {
+            console.error("Error sending password reset email:", error);
+            // Consider re-throwing a domain-specific error or HttpError
+            throw new Error("Failed to send password reset email.");
+        }
     }
 }


### PR DESCRIPTION
I've implemented the functionality to send password reset emails using nodemailer.

Key changes:
- Added `nodemailer`, `uuid`, and their respective type definitions as project dependencies.
- Updated `src/infraestructure/config/env.ts` to include environment variables for SMTP server configuration (host, port, user, pass, from email).
- Implemented `NodeMailerService` (`src/infraestructure/driven/services/node-mailer.service.ts`) to send emails:
    - Configured a nodemailer transporter using SMTP settings from environment variables.
    - Implemented the `sendRestorePasswordEmail` method to construct and send an HTML email containing a password reset token.
- Updated the `IMailService` interface (`src/domain/services/mail.service.ts`) to include the `token` parameter in the `sendRestorePasswordEmail` method.
- Modified `RestorePasswordUseCase` (`src/application/use-cases/auth.use-case.ts`):
    - To generate a unique token (UUID v4).
    - To pass the generated token to the `mailService.sendRestorePasswordEmail` method.
- Verified that InversifyJS dependency injection configuration in `src/infraestructure/ioc/config.ts` correctly binds `IMailService` to `NodeMailerService`.

This change allows the application to send an email to you when you request a password reset. The email includes a token that would be used in a subsequent step (not implemented here) to verify your identity and allow you to set a new password.