### PR TITLE
feat: Add Jest and configure for TypeScript

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: [
+    '**/__tests__/**/*.+(ts|tsx|js)',
+    '**/?(*.)+(spec|test).+(ts|tsx|js)'
+  ],
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest'
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -7,18 +7,22 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "dev": "nodemon"
+    "dev": "nodemon",
+    "test": "jest"
   },
   "devDependencies": {
     "@types/bun": "latest",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
+    "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.9",
     "@types/morgan": "^1.9.10",
-    "@types/pg": "^8.15.4",
     "@types/nodemailer": "^6.4.17",
+    "@types/pg": "^8.15.4",
     "@types/uuid": "^10.0.0",
+    "jest": "^30.0.3",
     "nodemon": "^3.1.10",
+    "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   },
@@ -31,9 +35,9 @@
     "inversify": "^7.5.2",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
+    "nodemailer": "^7.0.3",
     "pg": "^8.16.0",
     "reflect-metadata": "^0.2.2",
-    "nodemailer": "^7.0.3",
     "uuid": "^11.1.0"
   }
 }

--- a/src/__tests__/example.spec.ts
+++ b/src/__tests__/example.spec.ts
@@ -1,0 +1,5 @@
+describe('Example Test Suite', () => {
+  it('should pass this canary test', () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
- Installed Jest, ts-jest, and @types/jest.
- Created jest.config.js for TypeScript.
- Added a 'test' script to package.json.
- Added a sample test file to verify the setup.